### PR TITLE
Fix minor typo with loading of VTS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ load_module modules/ngx_http_fancyindex_module.so;
 load_module modules/ngx_http_uploadprogress_module.so;
 load_module modules/ngx_http_subs_filter_module.so;
 load_module modules/ngx_http_graphite_module.so;
-load module modules/ngx_http_vhost_traffic_status_module.so;
+load_module modules/ngx_http_vhost_traffic_status_module.so;
 load_module modules/ngx_ssl_ct_module.so 
 load_module modules/ngx_http_ssl_ct_module.so 
 load_module modules/ngx_mail_ssl_ct_module.so 

--- a/debian/nginx.conf
+++ b/debian/nginx.conf
@@ -37,7 +37,7 @@ pid /var/run/nginx.pid;
 #load_module modules/ngx_http_uploadprogress_module.so;
 #load_module modules/ngx_http_subs_filter_module.so;
 #load_module modules/ngx_http_graphite_module.so;
-#load module modules/ngx_http_vhost_traffic_status_module.so;
+#load_module modules/ngx_http_vhost_traffic_status_module.so;
 #load_module modules/ngx_ssl_ct_module.so 
 #load_module modules/ngx_http_ssl_ct_module.so 
 #load_module modules/ngx_mail_ssl_ct_module.so 


### PR DESCRIPTION
When uncommenting the line to load the VTS module, I noticed that it was missing an `_`. This PR fixes this.